### PR TITLE
separate the leaf results from results that should be written or overwritten

### DIFF
--- a/nereid/nereid/api/api_v1/models/watershed_models.py
+++ b/nereid/nereid/api/api_v1/models/watershed_models.py
@@ -409,7 +409,9 @@ class Watershed(BaseModel):
 
 class WatershedResults(BaseModel):
     results: List[Result]
+    leaf_results: List[Result]
     errors: Optional[List[str]] = None
+    warnings: Optional[List[str]] = None
 
 
 class WatershedResponse(JSONAPIResponse):

--- a/nereid/nereid/src/watershed/tasks.py
+++ b/nereid/nereid/src/watershed/tasks.py
@@ -30,12 +30,18 @@ def solve_watershed(
 
     build_nomo.cache_clear()
 
-    g, errors = initialize_graph(watershed, treatment_pre_validated, context,)
-    response["errors"] = errors
+    g, msgs = initialize_graph(watershed, treatment_pre_validated, context,)
+    response["errors"] = [e for e in msgs if "error" in e.lower()]
+    response["warnings"] = [w for w in msgs if "warning" in w.lower()]
 
-    solve_watershed_loading(g, context=context)
-    results = [dct for n, dct in g.nodes(data=True)]
+    if len(response["errors"]) == 0:  # pragma: no branch
+        solve_watershed_loading(g, context=context)
 
-    response["results"] = results
+        all_results = [dct for n, dct in g.nodes(data=True)]
+        results = [dct for dct in all_results if not dct["_is_leaf"]]
+        leafs = [dct for dct in all_results if dct["_is_leaf"]]
+
+        response["results"] = results
+        response["leaf_results"] = leafs
 
     return response

--- a/nereid/nereid/tests/test_api/test_watershed.py
+++ b/nereid/nereid/tests/test_api/test_watershed.py
@@ -44,7 +44,8 @@ def test_get_solve_watershed(client, watershed_responses, size, pct_tmnt):
     assert grjson["status"].lower() != "failure"
 
     if grjson["status"].lower() == "success":  # pragma: no branch
-        assert len(grjson["data"]["results"]) == size
+        grlen = len(grjson["data"]["results"]) + len(grjson["data"]["leaf_results"])
+        assert grlen == size, (grlen, size)
 
 
 def test_post_solve_watershed_stable(

--- a/nereid/nereid/tests/test_src/test_watershed/test_solve_watershed_sequence.py
+++ b/nereid/nereid/tests/test_src/test_watershed/test_solve_watershed_sequence.py
@@ -52,15 +52,13 @@ def test_watershed_solve_sequence(contexts, watershed_requests, n_nodes, pct_tmn
         subgraph_response_dict = solve_watershed(subg_request, False, context=context,)
         subgraph_results = subgraph_response_dict["results"]
 
-        _batch = [res for res in subgraph_results if not res["_is_leaf"]]
-        presults.extend(_batch)
-
-        db = db.combine_first(pandas.DataFrame(_batch).set_index("node_id"))
+        presults.extend(subgraph_results)
+        db = db.combine_first(pandas.DataFrame(subgraph_results).set_index("node_id"))
 
     response_dict = solve_watershed(
         watershed=watershed_request, treatment_pre_validated=False, context=context,
     )
-    results = response_dict["results"]
+    results = response_dict["results"] + response_dict["leaf_results"]
 
     check_db = pandas.DataFrame(results).set_index("node_id").sort_index(0)
     check_results_dataframes(db.sort_index(0), check_db)

--- a/nereid/nereid/tests/test_src/test_watershed/test_tasks.py
+++ b/nereid/nereid/tests/test_src/test_watershed/test_tasks.py
@@ -19,7 +19,7 @@ def test_solve_watershed_land_surface_only(contexts, watershed_requests, n_nodes
     response_dict = solve_watershed(
         watershed=watershed_request, treatment_pre_validated=False, context=context,
     )
-    result = response_dict["results"]
+    result = response_dict["results"] + response_dict["leaf_results"]
     outfall_results = [n for n in result if n["node_id"] == "0"][0]
     assert len(result) == len(watershed_request["graph"]["nodes"])
     assert all([len(n["node_errors"]) == 0 for n in result])
@@ -60,7 +60,7 @@ def test_solve_watershed_with_treatment(
         watershed=watershed_request, treatment_pre_validated=False, context=context,
     )
 
-    result = response_dict["results"]
+    result = response_dict["results"] + response_dict["leaf_results"]
     outfall_results = [n for n in result if n["node_id"] == "0"][0]
     assert len(result) == len(watershed_request["graph"]["nodes"])
     assert all([len(n["node_errors"]) == 0 for n in result])


### PR DESCRIPTION
This pr makes it easier for the client to insert results into the results database by pre-sorting the 'results' which need to overwrite old results, from the 'leaf_results' which are needed for the solution algorithm, but are read-only and so should not overwrite previous solutions.

closes #64 