### PR TITLE
generate node_id for all nodes and raise warning if node has no data

### DIFF
--- a/nereid/nereid/src/watershed/solve_watershed.py
+++ b/nereid/nereid/src/watershed/solve_watershed.py
@@ -177,6 +177,12 @@ def solve_node(
     data["node_warnings"] = []
     data["_is_leaf"] = False
 
+    if data.get("node_id") is None:
+        data["node_id"] = node
+        data["node_warnings"].append(
+            "WARNING: This node is missing from all input tables."
+        )
+
     # leaf nodes are read only
     if g.in_degree(node) < 1:
         data["_is_leaf"] = True

--- a/nereid/nereid/tests/test_src/test_watershed/test_solve_watershed.py
+++ b/nereid/nereid/tests/test_src/test_watershed/test_solve_watershed.py
@@ -375,6 +375,7 @@ def test_facility_load_reduction(contexts, tmnt_facility):
     solve_watershed_loading(g, context)
 
     assert all([len(dct["node_errors"]) == 0 for n, dct in g.nodes(data=True)])
+    assert len(g.nodes["0"]["node_warnings"]) >= 1  # there is no node_id for this node.
 
     sum_ret = sum(nx.get_node_attributes(g, "runoff_volume_cuft_retained").values())
     sum_inflow = sum(nx.get_node_attributes(g, "runoff_volume_cuft").values())


### PR DESCRIPTION
closes #69 
a "node_warning" will be attached for nodes in the network that have no attributes. they will continue to be skipped/ignored/pass through nodes, as before.