### PR TITLE
fix tmnt facility validation when given extra parameters

### DIFF
--- a/nereid/nereid/api/api_v1/endpoints/treatment_facilities.py
+++ b/nereid/nereid/api/api_v1/endpoints/treatment_facilities.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from fastapi import APIRouter, Body, Depends
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import ORJSONResponse
 
 import nereid.bg_worker as bg
@@ -98,14 +97,14 @@ def validate_facility_request(
         },
     ),
     context: dict = Depends(get_valid_context),
-) -> Tuple[TreatmentFacilitiesStrict, Dict[str, Any]]:
+) -> Tuple[TreatmentFacilities, Dict[str, Any]]:
 
     unvalidated_data = treatment_facilities.dict()["treatment_facilities"]
 
     valid_models = validate_treatment_facility_models(unvalidated_data, context)
 
     return (
-        TreatmentFacilitiesStrict.construct(treatment_facilities=valid_models),
+        TreatmentFacilities.construct(treatment_facilities=valid_models),
         context,
     )
 
@@ -117,7 +116,7 @@ def validate_facility_request(
     response_class=ORJSONResponse,
 )
 async def initialize_treatment_facility_parameters(
-    tmnt_facility_req: Tuple[TreatmentFacilitiesStrict, Dict[str, Any]] = Depends(
+    tmnt_facility_req: Tuple[TreatmentFacilities, Dict[str, Any]] = Depends(
         validate_facility_request
     )
 ) -> Dict[str, Any]:

--- a/nereid/nereid/api/api_v1/endpoints/watershed.py
+++ b/nereid/nereid/api/api_v1/endpoints/watershed.py
@@ -1,16 +1,14 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Tuple
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import ORJSONResponse
 
 import nereid.bg_worker as bg
 from nereid.api.api_v1.models.treatment_facility_models import (
-    TreatmentFacilitiesStrict,
     validate_treatment_facility_models,
 )
 from nereid.api.api_v1.models.watershed_models import Watershed, WatershedResponse
 from nereid.api.api_v1.utils import get_valid_context, run_task, standard_json_response
-from nereid.src.watershed.tasks import solve_watershed
 
 router = APIRouter()
 
@@ -26,12 +24,8 @@ def validate_watershed_request(
         valid_models = validate_treatment_facility_models(
             unvalidated_treatment_facilities, context
         )
-        validated_treatment_facilities = TreatmentFacilitiesStrict.construct(
-            treatment_facilities=valid_models
-        )
-        watershed["treatment_facilities"] = validated_treatment_facilities.dict()[
-            "treatment_facilities"
-        ]
+
+        watershed["treatment_facilities"] = valid_models
 
     return watershed, context
 

--- a/nereid/nereid/core/utils.py
+++ b/nereid/nereid/core/utils.py
@@ -1,8 +1,7 @@
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
-import pandas
 from pydantic import BaseModel, ValidationError
 
 from nereid.core.config import APP_CONTEXT
@@ -89,43 +88,6 @@ def get_request_context(
     request_context["data_path"] = str(data_path)
 
     return request_context
-
-
-def validate_models_with_discriminator(
-    unvalidated_data: List[Dict[str, Any]],
-    discriminator: str,
-    model_mapping: Dict[str, Any],
-    fallback_mapping: Dict[str, Any],
-) -> List[Any]:
-    class NullModel(BaseModel):
-        class Config:
-            extra = "allow"
-
-    validated = []
-    for dct in unvalidated_data:
-        attr = dct[discriminator]
-        model = model_mapping.get(attr, None)
-        fallback = fallback_mapping.get(attr, NullModel)
-
-        if model is None:
-            e = (
-                f"ERROR: the key '{attr}' is not in `model_mapping`. "
-                f"Using `fallback` value: {fallback.schema()['title']}"
-            )
-
-            dct["errors"] = str(e) + "  \n"
-            model = fallback
-        try:
-            valid = model(valid_model=model.schema()["title"], **dct)
-
-        except ValidationError as e:
-            dct["errors"] = "ERROR: " + str(e) + "  \n"
-            model = fallback
-            valid = model(valid_model=model.schema()["title"], **dct)
-
-        validated.append(valid)
-
-    return validated
 
 
 def validate_with_discriminator(

--- a/nereid/nereid/src/treatment_facility/constructors.py
+++ b/nereid/nereid/src/treatment_facility/constructors.py
@@ -27,6 +27,7 @@ def construct_treatment_facility_node_context(
     n_cxt: Dict[str, Any] = deepcopy(node_context)
 
     constructor_str = n_cxt.get("constructor", "nt_facility_constructor")
+    # constructor_str = n_cxt.get("constructor") or "nt_facility_constructor" # TODO doubletap
     fxn = getattr(TreatmentFacilityConstructor, constructor_str)
 
     result = fxn(**n_cxt)

--- a/nereid/nereid/src/treatment_facility/constructors.py
+++ b/nereid/nereid/src/treatment_facility/constructors.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List
 
 import pandas
 
@@ -26,8 +26,7 @@ def construct_treatment_facility_node_context(
 
     n_cxt: Dict[str, Any] = deepcopy(node_context)
 
-    constructor_str = n_cxt.get("constructor", "nt_facility_constructor")
-    # constructor_str = n_cxt.get("constructor") or "nt_facility_constructor" # TODO doubletap
+    constructor_str = n_cxt.get("constructor") or "nt_facility_constructor"
     fxn = getattr(TreatmentFacilityConstructor, constructor_str)
 
     result = fxn(**n_cxt)

--- a/nereid/nereid/src/treatment_facility/tasks.py
+++ b/nereid/nereid/src/treatment_facility/tasks.py
@@ -19,10 +19,9 @@ def initialize_treatment_facilities(
 
     treatment_facility_list = treatment_facilities.get("treatment_facilities") or []
     if not pre_validated:
-        tmnt_model = validate_treatment_facility_models(
+        treatment_facility_list = validate_treatment_facility_models(
             treatment_facility_list, context
         )
-        treatment_facility_list = [m.dict() for m in tmnt_model]
 
     df, messages = parse_configuration_logic(
         df=pandas.DataFrame(treatment_facility_list),

--- a/nereid/nereid/tests/test_api/conftest.py
+++ b/nereid/nereid/tests/test_api/conftest.py
@@ -125,11 +125,11 @@ def land_surface_loading_responses(client, land_surface_loading_response_dicts):
 
 
 @pytest.fixture(scope="module")
-def treatment_facility_responses(client, valid_treatment_facility_dicts):
+def treatment_facility_responses(client, treatment_facility_dicts):
 
     responses = {}
 
-    for name, dct in valid_treatment_facility_dicts.items():
+    for name, dct in treatment_facility_dicts.items():
 
         payload = json.dumps({"treatment_facilities": [dct]})
         route = API_LATEST + "/treatment_facility/validate"

--- a/nereid/nereid/tests/test_api/test_models.py
+++ b/nereid/nereid/tests/test_api/test_models.py
@@ -105,7 +105,7 @@ def test_build_treatment_facility_nodes_errors(contexts, ctxt_key, err, data_dic
     tmnt_facilities = [data_dict]
     valid_models = validate_treatment_facility_models(tmnt_facilities, context)
 
-    vm_dict = valid_models[0].dict()
+    vm_dict = valid_models[0]
 
     if err:
         assert err in vm_dict["errors"]

--- a/nereid/nereid/tests/test_src/test_treatment_facility/test_constructors.py
+++ b/nereid/nereid/tests/test_src/test_treatment_facility/test_constructors.py
@@ -30,7 +30,6 @@ def test_build_treatment_facility_nodes(
 ):
 
     context = contexts[ctxt_key]
-    print(valid_treatment_facility_dicts[model])
     tmnt_facilities = pandas.DataFrame([valid_treatment_facility_dicts[model]])
     df, messages = parse_configuration_logic(
         df=pandas.DataFrame(tmnt_facilities),
@@ -41,12 +40,12 @@ def test_build_treatment_facility_nodes(
     node = build_treatment_facility_nodes(df)[0]
 
     check_val = node.get(checkfor)
-    assert isinstance(check_val, float)
+    assert isinstance(check_val, (int, float)), (node, model, checkfor)
 
     if has_met_data:
-        assert node.get("rain_gauge") is not None
+        assert node.get("rain_gauge") is not None, (node, model, checkfor)
     else:
-        assert node.get("rain_gauge") is None
+        assert node.get("rain_gauge") is None, (node, model, checkfor)
 
 
 @pytest.mark.parametrize(
@@ -85,7 +84,7 @@ def test_build_diversion_facility_months_operational(
 
     tmnt_facilities = (
         pandas.DataFrame(valid_treatment_facilities)
-        .query("facility_type=='LowFlowFacility'")
+        .query("valid_model=='LowFlowFacility'")
         .assign(months_operational=months_operational)
     )
 
@@ -98,7 +97,8 @@ def test_build_diversion_facility_months_operational(
     nodes = build_treatment_facility_nodes(df)
 
     for n in nodes:
+        assert n, "error: no data created"
         if is_zero:
-            assert n.get("summer_dry_weather_retention_rate_cfs") == 0.0
+            assert n.get("summer_dry_weather_retention_rate_cfs") == 0.0, n
         else:
-            assert n.get("summer_dry_weather_retention_rate_cfs") > 0.0
+            assert n.get("summer_dry_weather_retention_rate_cfs") > 0.0, n

--- a/nereid/nereid/tests/test_src/test_treatment_facility/test_tasks.py
+++ b/nereid/nereid/tests/test_src/test_treatment_facility/test_tasks.py
@@ -72,7 +72,7 @@ def test_construct_nodes_from_treatment_facility_request_checkval(
 
 @pytest.mark.parametrize("pre_validated", [True, False])
 def test_construct_nodes_from_treatment_facility_request_pre_validation(
-    contexts, valid_treatment_facility_dicts, pre_validated
+    contexts, treatment_facility_dicts, valid_treatment_facility_dicts, pre_validated
 ):
 
     context = contexts["default"]
@@ -80,8 +80,13 @@ def test_construct_nodes_from_treatment_facility_request_pre_validation(
     model_map = {k: dct["validator"] for k, dct in facilities.items()}
     _tmnt_ls = []
 
+    if pre_validated:
+        facility_dicts = valid_treatment_facility_dicts
+    else:
+        facility_dicts = treatment_facility_dicts
+
     for k, model in model_map.items():
-        dct = valid_treatment_facility_dicts[model]
+        dct = facility_dicts[model]
         dct["facility_type"] = k
         _tmnt_ls.append(dct)
 

--- a/nereid/nereid/tests/utils.py
+++ b/nereid/nereid/tests/utils.py
@@ -186,7 +186,6 @@ def generate_random_treatment_facility_request_node(
 ):
     model = getattr(treatment_facility_models, model_str)
     dct = create_random_model_dict(model=model, can_fail=False)
-    _ = dct.pop("constructor")
 
     dct["node_id"] = node_id
     dct["facility_type"] = facility_type
@@ -264,7 +263,7 @@ def generate_random_validated_treatment_facility_node(context,):  # pragma: no c
         [facility], context=context
     )[0]
 
-    return validated_facility_model.dict()
+    return validated_facility_model
 
 
 def generate_random_land_surface_request_sliver(

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,12 @@
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("nereid/nereid/__init__.py", encoding="utf8") as f:
     content = f.read()
     version = re.search(r'__version__ = "(.*?)"', content).group(1)
     author = re.search(r'__author__ = "(.*?)"', content).group(1)
     author_email = re.search(r'__email__ = "(.*?)"', content).group(1)
-
-print(find_packages())
 
 
 setup(


### PR DESCRIPTION
prevent collisions and overwrites when the extra parameters are valid for other BMP types.

previously broken case included 'hsg' = 'd' for an infiltration basin. The RetentionFacility type doesn't take hsg, instead the user must submit inf_rate_inhr explicitly. In this case, the configuration remaps processor would see the 'hsg' field and remap it to something like 0.024 in/hr, thus nuking the user defined value.

the fix is to 'ignore' all extra keys on user submitted data. 

This led to several issues since the program needs to add new keys to the model during initialization to trace what models ended up getting validated or if the fallback was used. Anyway, this is a larger diff since this change altered the validation code and the tests.